### PR TITLE
change: phpmd rule. phpmd2.7, 2.8 で追加されたルールの無効化

### DIFF
--- a/files/default/build/cakephp/phpmd/rules.xml
+++ b/files/default/build/cakephp/phpmd/rules.xml
@@ -17,6 +17,8 @@
         <!-- Exclude the rule for static access like ClassRegistry::init('Foo');. -->
         <exclude name="StaticAccess" />
         <exclude name="ElseExpression" />
+        <exclude name="MissingImport" />
+        <exclude name="UndefinedVariable" />
     </rule>
     <rule ref="rulesets/codesize.xml" />
     <rule ref="rulesets/design.xml" />


### PR DESCRIPTION
phpmd2.8にあるMissingImport, UndefinedVariableルールを無効化。
